### PR TITLE
dynamically change the title

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+  BASE_TITLE = "GI Sports".freeze
+
+  def full_title(page_title)
+    page_title.blank? ? BASE_TITLE : "#{page_title} | #{BASE_TITLE}"
+  end
 end

--- a/app/views/beginners/index.html.erb
+++ b/app/views/beginners/index.html.erb
@@ -1,3 +1,7 @@
+<!-- TITLE -->
+<% provide(:title, "はじめての方") %>
+
+<!-- VIEW -->
 <div class="wrap_home">
   <div class="main_home row justify-content-center">
     <div class="message-to-beginner my-4">

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -1,3 +1,4 @@
+<!-- VIEW -->
 <div class="wrap_home">
   <div class="background_home position-relative">
     <div class="position-absolute concept-text">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
   <head>
-    <title>GIsApp</title>
+    <title><%= full_title(yield(:title)) %></title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>

--- a/app/views/schools/edit.html.erb
+++ b/app/views/schools/edit.html.erb
@@ -1,3 +1,6 @@
+<!-- TITLE -->
+<% provide(:title, "スクール情報編集") %>
+
 <!-- FLASH -->
 <%= render 'shared/flash_success' %>
 <%= render 'shared/flash_danger' %>

--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -1,3 +1,7 @@
+<!-- TITLE -->
+<% provide(:title, "登録済スクール") %>
+
+<!-- VIEW -->
 <div class="container px-5">
   <h3 class="my-4 ms-3 p-1">登録済スクール一覧</h3>
   <% if current_user.schools.count == 0 %>

--- a/app/views/schools/new.html.erb
+++ b/app/views/schools/new.html.erb
@@ -1,3 +1,6 @@
+<!-- TITLE -->
+<% provide(:title, "スクール登録") %>
+
 <!-- FLASH -->
 <%= render 'shared/flash_danger' %>
 

--- a/app/views/schools/search.html.erb
+++ b/app/views/schools/search.html.erb
@@ -1,3 +1,7 @@
+<!-- TITLE -->
+<% provide(:title, "検索結果") %>
+
+<!-- VIEW -->
 <div class="container px-5">
   <div class="row">
     <div class="col_search mx-auto">

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -1,3 +1,7 @@
+<!-- TITLE -->
+<% provide(:title, @school.school_name) %>
+
+<!-- VIEW -->
 <div class="container px-5">
   <div class="row">
     <div class="col_search mx-auto">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,3 +1,6 @@
+<!-- TITLE -->
+<% provide(:title, "ログイン") %>
+
 <!-- FLASH -->
 <%= render 'shared/flash_danger' %>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,6 @@
+<!-- TITLE -->
+<% provide(:title, "アカウント設定") %>
+
 <!-- FLASH -->
 <%= render 'shared/flash_success' %>
 <%= render 'shared/flash_danger' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,6 @@
+<!-- TITLE -->
+<% provide(:title, "新規会員登録") %>
+
 <!-- FLASH -->
 <%= render 'shared/flash_danger' %>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -6,16 +6,19 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context "page_titleが存在する場合に動的な表示がなされること" do
       let(:page_title) { "sample" }
+
       it { expect(subject).to eq "sample | GI Sports" }
     end
 
     context "page_titleが空白の場合に動的な表示がなされること" do
       let(:page_title) { "" }
+
       it { expect(subject).to eq "GI Sports" }
     end
 
     context "page_titleがnilの場合に動的な表示がなされること" do
       let(:page_title) { nil }
+
       it { expect(subject).to eq "GI Sports" }
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#full_title" do
+    subject { full_title(page_title) }
+
+    context "page_titleが存在する場合に動的な表示がなされること" do
+      let(:page_title) { "sample" }
+      it { expect(subject).to eq "sample | GI Sports" }
+    end
+
+    context "page_titleが空白の場合に動的な表示がなされること" do
+      let(:page_title) { "" }
+      it { expect(subject).to eq "GI Sports" }
+    end
+
+    context "page_titleがnilの場合に動的な表示がなされること" do
+      let(:page_title) { nil }
+      it { expect(subject).to eq "GI Sports" }
+    end
+  end
+end


### PR DESCRIPTION
### 動的にタイトルを変える

・ホーム画面は、"GI Sports"
・スクール詳細ページは、"スクール名 | GI Sports"
・それ以外のページは、"固定文字列 | GI Sports"
例：ログイン画面だと、"ログイン | GI Sports"
・タイトルが動的に表示されることのテストを追加

-参考サイト-
https://bokunonikki.net/post/2019/0405_rails_title_dynamically_change_ja/